### PR TITLE
Fix content-type check

### DIFF
--- a/lib/infinum_json_api_setup/json_api/content_negotiation.rb
+++ b/lib/infinum_json_api_setup/json_api/content_negotiation.rb
@@ -16,6 +16,8 @@ module InfinumJsonApiSetup
       end
 
       def valid_content_type?
+        return true if request.body.length.zero?
+
         request.content_type == Mime.fetch(:json_api)
       end
 


### PR DESCRIPTION
Check content-type only if the request contains a non-empty body