### PR TITLE
Use size instead of length for checking request body size

### DIFF
--- a/lib/infinum_json_api_setup/json_api/content_negotiation.rb
+++ b/lib/infinum_json_api_setup/json_api/content_negotiation.rb
@@ -16,7 +16,7 @@ module InfinumJsonApiSetup
       end
 
       def valid_content_type?
-        return true if request.body.length.zero?
+        return true if request.body.size.zero?
 
         request.content_type == Mime.fetch(:json_api)
       end


### PR DESCRIPTION
I got errors on staging and development:
```
> undefined method `length' for #<Puma::NullIO:0x00007fa8330e24b8>
undefined method `length' for #<PhusionPassenger::Utils::TeeInput:0x000055a03e0b6d80>
```

`Puma::NullIO` and `PhusionPassenger::Utils::TeeInput` both implement `size` instead of `length`