### PR TITLE
Fix size attribute in pagination links

### DIFF
--- a/lib/infinum_json_api_setup/json_api/serializer_options.rb
+++ b/lib/infinum_json_api_setup/json_api/serializer_options.rb
@@ -31,6 +31,7 @@ module InfinumJsonApiSetup
           total_pages: pagination_details.pages,
           total_count: pagination_details.count,
           padding: pagination_details.vars.fetch(:outset).to_i,
+          page_size: pagination_details.vars.fetch(:items).to_i,
           max_page_size: Pagy::VARS[:max_items]
         }
       end
@@ -53,7 +54,7 @@ module InfinumJsonApiSetup
         link_params = params.deep_dup
         link_params[:page] = {
           number: page,
-          size: pagination_details.items,
+          size: pagination_details.vars[:items],
           padding: pagination_details.vars[:outset]
         }.compact
 

--- a/lib/infinum_json_api_setup/json_api/serializer_options.rb
+++ b/lib/infinum_json_api_setup/json_api/serializer_options.rb
@@ -54,8 +54,8 @@ module InfinumJsonApiSetup
         link_params = params.deep_dup
         link_params[:page] = {
           number: page,
-          size: pagination_details.vars[:items],
-          padding: pagination_details.vars[:outset]
+          size: pagination_details.vars.fetch(:items),
+          padding: pagination_details.vars.fetch(:outset)
         }.compact
 
         Rails.application.routes.url_helpers.url_for(link_params)


### PR DESCRIPTION
Size attribute wasn't properly fetched from pagination details. 

It should have been fetched from vars hash because that's where you can find an information about requested page size that should be used in pagination links. 