### PR TITLE
Determine serializer name by controller path

### DIFF
--- a/lib/infinum_json_api_setup/rails.rb
+++ b/lib/infinum_json_api_setup/rails.rb
@@ -15,7 +15,7 @@ ActiveSupport.on_load(:action_controller) do
       end
 
       serializer = opts.delete(:serializer) do
-        "Api::V1::#{controller_name.classify.pluralize}::Serializer".constantize
+        "#{controller_path.classify.pluralize}::Serializer".constantize
       end
       options = InfinumJsonApiSetup::JsonApi::SerializerOptions.new(
         params: params.to_unsafe_h, pagination_details: opts[:pagination_details]


### PR DESCRIPTION
A fix for using scopes in controllers, for example:
`Api::V1::Auth::SessionsController`, and Auth is only a scope in routes.
```ruby
  namespace :api do
    namespace :v1 do
      scope module: :auth do
        resources :sessions, only: [:show, :create, :destroy]
      end
    end
  end
```

It also works for custom namespaces (Api::V2, Something::Else, ...)