### PR TITLE
Skip serializer initialization for no_content status

### DIFF
--- a/lib/infinum_json_api_setup/rails.rb
+++ b/lib/infinum_json_api_setup/rails.rb
@@ -13,6 +13,7 @@ ActiveSupport.on_load(:action_controller) do
       if resources.is_a?(InfinumJsonApiSetup::Error::Base)
         break InfinumJsonApiSetup::JsonApi::ErrorSerializer.new(resources).serialized_json
       end
+      break if opts[:status] == 204
 
       serializer = opts.delete(:serializer) do
         "#{controller_path.classify.pluralize}::Serializer".constantize


### PR DESCRIPTION
Skip serializer initialization for **no_content** status.

I was getting an error for the following controller action because I didn't have _Api::V1::Auth::Confirmations::Serializer_ defined.
There is no need to define serializer for no content response.
```ruby
module Api
  module V1
    module Auth
      class ConfirmationsController < BaseController
        # POST /api/v1/confirmation
        def create
          user = User.send_confirmation_instructions(create_params)

          respond_with user, status: :no_content
        end

        private

        def create_params
          params.from_jsonapi.require(:confirmation).permit(:email)
        end
      end
    end
  end
end
```