### PR TITLE
Allow setting relationships to nil

### DIFF
--- a/lib/infinum_json_api_setup/rspec/helpers/request_helper.rb
+++ b/lib/infinum_json_api_setup/rspec/helpers/request_helper.rb
@@ -48,6 +48,7 @@ module InfinumJsonApiSetup
             data: case relationship
                   when Array then relationship.map { |rel| rel.slice(:id, :type) }
                   when Hash then relationship.slice(:id, :type)
+                  when NilClass then nil
                   else raise ArgumentError 'relationship must be either an array or hash'
                   end
           }


### PR DESCRIPTION
Frontend will sometimes send a relationship set to nil for empty has_one relationships.

Example:
```
 "relationships": {
     "some_has_one_relationship": {
          "data": null
      }
}
```