### PR TITLE
Add serializer options specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'factory_bot', '~> 6.2'
+gem 'faker', '~> 2.18'
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,10 @@ GEM
     ecma-re-validator (0.3.0)
       regexp_parser (~> 2.0)
     erubi (1.10.0)
+    factory_bot (6.2.0)
+      activesupport (>= 5.0.0)
+    faker (2.18.0)
+      i18n (>= 1.6, < 2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hana (1.3.7)
@@ -217,6 +221,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  factory_bot (~> 6.2)
+  faker (~> 2.18)
   infinum_json_api_setup!
   jsonapi-query_builder
   jsonapi-serializer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)

--- a/spec/dummy/app/controllers/api/v1/locations_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/locations_controller.rb
@@ -9,7 +9,7 @@ module Api
       def index
         q = Api::V1::Locations::Query.new(Location.all, params.to_unsafe_hash)
 
-        respond_with q.results
+        respond_with q.results, pagination_details: q.pagination_details
       end
 
       # GET /api/v1/locations

--- a/spec/dummy/app/models/location.rb
+++ b/spec/dummy/app/models/location.rb
@@ -7,6 +7,8 @@ class Location < ApplicationRecord
   X_AXIS = :x_axis
   Y_AXIS = :y_axis
 
+  has_many :labels, class_name: 'LocationLabel'
+
   # @return [Integer]
   def quadrant # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     if latitude.positive? && longitude.positive?

--- a/spec/dummy/app/models/location_label.rb
+++ b/spec/dummy/app/models/location_label.rb
@@ -1,0 +1,3 @@
+class LocationLabel < ApplicationRecord
+  belongs_to :location
+end

--- a/spec/dummy/app/web/api/v1/locations/label_serializer.rb
+++ b/spec/dummy/app/web/api/v1/locations/label_serializer.rb
@@ -1,12 +1,10 @@
 module Api
   module V1
     module Locations
-      class Serializer
+      class LabelSerializer
         include JSONAPI::Serializer
 
-        has_many :labels, serializer: LabelSerializer
-        attribute :latitude
-        attribute :longitude
+        attribute :title
         attribute :created_at
         attribute :updated_at
       end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -56,4 +56,5 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+  Rails.application.routes.default_url_options = { host: 'https://api.example.com' }
 end

--- a/spec/dummy/db/migrate/20210709100750_create_locations.rb
+++ b/spec/dummy/db/migrate/20210709100750_create_locations.rb
@@ -4,7 +4,7 @@ class CreateLocations < ActiveRecord::Migration[6.1]
       t.decimal :latitude, precision: 10, scale: 8, null: false
       t.decimal :longitude, precision: 11, scale: 8, null: false
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/spec/dummy/db/migrate/20210714104736_create_location_labels.rb
+++ b/spec/dummy/db/migrate/20210714104736_create_location_labels.rb
@@ -1,0 +1,10 @@
+class CreateLocationLabels < ActiveRecord::Migration[6.1]
+  def change
+    create_table :location_labels do |t|
+      t.references :location, null: false, foreign_key: true
+      t.string :title, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_09_100750) do
+ActiveRecord::Schema.define(version: 2021_07_14_104736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "location_labels", force: :cascade do |t|
+    t.bigint "location_id", null: false
+    t.string "title", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["location_id"], name: "index_location_labels_on_location_id"
+  end
 
   create_table "locations", force: :cascade do |t|
     t.decimal "latitude", precision: 10, scale: 8, null: false
@@ -22,4 +30,5 @@ ActiveRecord::Schema.define(version: 2021_07_09_100750) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "location_labels", "locations"
 end

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :location do
+    latitude { Faker::Number.between(from: -90, to: 90) }
+    longitude { Faker::Number.between(from: -180, to: 180) }
+
+    trait :fourth_quadrant do
+      latitude { Faker::Number.between(from: -0.1, to: -90) }
+      longitude { Faker::Number.between(from: -0.1, to: -180) }
+    end
+  end
+end

--- a/spec/factories/location_label.rb
+++ b/spec/factories/location_label.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :location_label do
+    title { Faker::Color.color_name }
+    location
+  end
+end

--- a/spec/requests/api/v1/error_handling_spec.rb
+++ b/spec/requests/api/v1/error_handling_spec.rb
@@ -22,7 +22,7 @@ describe 'Error handling', type: :request do
 
   context 'when client is not authorized to perform requested action' do
     it 'responds with 403 Forbidden' do
-      loc = Location.create(latitude: -1, longitude: -1)
+      loc = create(:location, :fourth_quadrant)
       get "/api/v1/locations/#{loc.id}", headers: default_headers
 
       expect(response).to have_http_status(:forbidden)

--- a/spec/requests/api/v1/serializer_options_spec.rb
+++ b/spec/requests/api/v1/serializer_options_spec.rb
@@ -1,0 +1,53 @@
+require 'cgi'
+require 'uri'
+
+describe 'Serializer options', type: :request do
+  it 'adds meta with pagination information' do # rubocop:disable RSpec/MultipleExpectations
+    get '/api/v1/locations', params: {}, headers: default_headers
+
+    expect(response).to have_http_status(:ok)
+    expect(json_response).to have_key('meta')
+    meta = json_response['meta']
+    expect(meta).to have_key('current_page')
+    expect(meta).to have_key('total_pages')
+    expect(meta).to have_key('total_count')
+    expect(meta).to have_key('padding')
+    expect(meta).to have_key('page_size')
+    expect(meta).to have_key('max_page_size')
+  end
+
+  it 'adds links' do
+    get '/api/v1/locations', params: {}, headers: default_headers
+
+    expect(response).to have_http_status(:ok)
+    expect(json_response).to have_key('links')
+    links = json_response['links']
+    expect(links).to have_key('self')
+    expect(links).to have_key('first')
+    expect(links).to have_key('last')
+  end
+
+  it 'adds client requested fields information to links' do
+    q = { fields: { locations: 'latitude' } }
+    get "/api/v1/locations?#{q.to_query}", params: {}, headers: default_headers
+
+    expect(response).to have_http_status(:ok)
+    self_link = json_response.dig('links', 'self')
+    expect(parse_query(self_link)).to have_key('fields[locations]')
+  end
+
+  it 'adds client requested include information to links' do
+    q = { include: 'labels' }
+    get "/api/v1/locations?#{q.to_query}", params: {}, headers: default_headers
+
+    expect(response).to have_http_status(:ok)
+    self_link = json_response.dig('links', 'self')
+    expect(parse_query(self_link)).to have_key('include')
+  end
+
+  private
+
+  def parse_query(link)
+    CGI.parse(URI(link).query)
+  end
+end

--- a/spec/requests/api/v1/serializer_options_spec.rb
+++ b/spec/requests/api/v1/serializer_options_spec.rb
@@ -2,18 +2,14 @@ require 'cgi'
 require 'uri'
 
 describe 'Serializer options', type: :request do
-  it 'adds meta with pagination information' do # rubocop:disable RSpec/MultipleExpectations
+  it 'adds meta with pagination information' do
     get '/api/v1/locations', params: {}, headers: default_headers
 
     expect(response).to have_http_status(:ok)
     expect(json_response).to have_key('meta')
-    meta = json_response['meta']
-    expect(meta).to have_key('current_page')
-    expect(meta).to have_key('total_pages')
-    expect(meta).to have_key('total_count')
-    expect(meta).to have_key('padding')
-    expect(meta).to have_key('page_size')
-    expect(meta).to have_key('max_page_size')
+    expect(json_response['meta'].keys).to include(
+      'current_page', 'total_pages', 'total_count', 'padding', 'page_size', 'max_page_size'
+    )
   end
 
   it 'adds links' do
@@ -21,10 +17,7 @@ describe 'Serializer options', type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(json_response).to have_key('links')
-    links = json_response['links']
-    expect(links).to have_key('self')
-    expect(links).to have_key('first')
-    expect(links).to have_key('last')
+    expect(json_response['links'].keys).to include('self', 'first', 'last')
   end
 
   it 'adds client requested fields information to links' do

--- a/spec/requests/api/v1/serializer_options_spec.rb
+++ b/spec/requests/api/v1/serializer_options_spec.rb
@@ -25,8 +25,8 @@ describe 'Serializer options', type: :request do
     get "/api/v1/locations?#{q.to_query}", params: {}, headers: default_headers
 
     expect(response).to have_http_status(:ok)
-    self_link = json_response.dig('links', 'self')
-    expect(parse_query(self_link)).to have_key('fields[locations]')
+    expect(query_params(json_response.dig('links', 'self')))
+      .to include('fields[locations]' => ['latitude'])
   end
 
   it 'adds client requested include information to links' do
@@ -34,13 +34,13 @@ describe 'Serializer options', type: :request do
     get "/api/v1/locations?#{q.to_query}", params: {}, headers: default_headers
 
     expect(response).to have_http_status(:ok)
-    self_link = json_response.dig('links', 'self')
-    expect(parse_query(self_link)).to have_key('include')
+    expect(query_params(json_response.dig('links', 'self')))
+      .to include('include' => ['labels'])
   end
 
   private
 
-  def parse_query(link)
+  def query_params(link)
     CGI.parse(URI(link).query)
   end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
+end


### PR DESCRIPTION
### Aim
Add specs for `InfinumJsonApiSetup::JsonApi::SerializerOptions`

#### Solution
- add factory bot and faker
- add location label association to location model (in order to later test `?include` param)
- add serializer options specs