### PR TITLE
Add specs for include_all_resource_ids matcher

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Max: 5
 
+Style/AccessorGrouping:
+  EnforcedStyle: separated
+
 AllCops:
   TargetRubyVersion: 2.7
   Exclude:

--- a/lib/infinum_json_api_setup/rspec.rb
+++ b/lib/infinum_json_api_setup/rspec.rb
@@ -1,10 +1,13 @@
 require 'infinum_json_api_setup/rspec/matchers/schema_matchers'
 require 'infinum_json_api_setup/rspec/matchers/body_matchers'
+require 'infinum_json_api_setup/rspec/matchers/include_all_resource_ids'
 
 require 'infinum_json_api_setup/rspec/helpers/request_helper'
 require 'infinum_json_api_setup/rspec/helpers/response_helper'
 
 RSpec.configure do |config|
+  config.include InfinumJsonApiSetup::RSpec::Matchers
+
   config.add_setting :schema_response_root
   config.add_setting :schema_request_root
 end

--- a/lib/infinum_json_api_setup/rspec/matchers/body_matchers.rb
+++ b/lib/infinum_json_api_setup/rspec/matchers/body_matchers.rb
@@ -1,11 +1,3 @@
-RSpec::Matchers.define :include_all_resource_ids do |params|
-  match do |response|
-    body = JSON.parse(response.body)
-    resource_ids = body['data'].map { |resource| resource['id'].to_i }
-    params.sort == resource_ids.sort
-  end
-end
-
 RSpec::Matchers.define :include_all_resource_string_ids do |params|
   match do |response|
     body = JSON.parse(response.body)

--- a/lib/infinum_json_api_setup/rspec/matchers/include_all_resource_ids.rb
+++ b/lib/infinum_json_api_setup/rspec/matchers/include_all_resource_ids.rb
@@ -1,0 +1,51 @@
+require 'json'
+
+module InfinumJsonApiSetup
+  module RSpec
+    module Matchers
+      # @return [InfinumJsonApiSetup::Rspec::Matchers::IncludeAllResourceIds]
+      def include_all_resource_ids(*args)
+        IncludeAllResourceIds.new(*args)
+      end
+
+      class IncludeAllResourceIds
+        # @param [Array<Integer>] required_ids
+        def initialize(required_ids)
+          @required_ids = required_ids.sort
+        end
+
+        # @param [ActionDispatch::TestResponse] response
+        # @return [Boolean]
+        def matches?(response)
+          @response = response
+
+          actual_ids == required_ids.sort
+        rescue JSON::ParserError => _e
+          @error_message = 'Failed to parse response body'
+          false
+        rescue KeyError => _e
+          @error_message = 'Failed to extract data from response body'
+          false
+        end
+
+        # @return [String]
+        def failure_message
+          @error_message || "Expected response ID's(#{actual_ids}) to match #{required_ids}"
+        end
+
+        private
+
+        attr_reader :response
+        attr_reader :required_ids
+
+        def actual_ids
+          @actual_ids ||= JSON
+                          .parse(response.body)
+                          .fetch('data')
+                          .map { |resource| resource['id'].to_i }
+                          .sort
+        end
+      end
+    end
+  end
+end

--- a/spec/infinum_json_api_setup/rspec/matchers/include_all_resource_ids_spec.rb
+++ b/spec/infinum_json_api_setup/rspec/matchers/include_all_resource_ids_spec.rb
@@ -1,0 +1,55 @@
+describe InfinumJsonApiSetup::RSpec::Matchers::IncludeAllResourceIds do
+  describe 'usage' do
+    context "when ID's match" do
+      it 'matches' do
+        response = response_with_ids([1, 2])
+
+        expect(response).to include_all_resource_ids([1, 2])
+      end
+
+      it "doesn't consider ordering" do
+        response = response_with_ids([1, 2, 3])
+
+        expect(response).to include_all_resource_ids([3, 2, 1])
+      end
+    end
+
+    context "when ID's don't match" do
+      it 'fails and describes failure reason' do
+        response = response_with_ids([1, 2, 3])
+
+        expect do
+          expect(response).to include_all_resource_ids([4])
+        end.to fail_with("Expected response ID's([1, 2, 3]) to match [4]")
+      end
+    end
+
+    context "when response isn't valid JSON" do
+      it 'fails and describes failure reason' do
+        response = response_with_body('')
+
+        expect do
+          expect(response).to include_all_resource_ids([1])
+        end.to fail_with('Failed to parse response body')
+      end
+    end
+
+    context "when response doesn't contain data attribute" do
+      it 'fails and describes failure reason' do
+        response = response_with_body('{}')
+
+        expect do
+          expect(response).to include_all_resource_ids([1])
+        end.to fail_with('Failed to extract data from response body')
+      end
+    end
+  end
+
+  def response_with_ids(ids)
+    response_with_body(JSON.dump(data: ids.map { |id| { 'id' => id } }))
+  end
+
+  def response_with_body(body)
+    ActionDispatch::TestResponse.new(200, {}, body)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,11 +72,6 @@ RSpec.configure do |config|
   # Enables running rspec --only-failures
   config.example_status_persistence_file_path = 'spec/examples.txt'
 
-  # Aggregate test failures
-  config.define_derived_metadata do |meta|
-    meta[:aggregate_failures] = true
-  end
-
   config.include TestHelpers::Request, type: :request
   config.include TestHelpers::Response, type: :request
 end

--- a/spec/support/infinum_json_api_setup.rb
+++ b/spec/support/infinum_json_api_setup.rb
@@ -1,0 +1,1 @@
+require 'infinum_json_api_setup/rspec'

--- a/spec/support/rspec_expectations.rb
+++ b/spec/support/rspec_expectations.rb
@@ -1,0 +1,5 @@
+require 'rspec/matchers/fail_matchers'
+
+RSpec.configure do |config|
+  config.include RSpec::Matchers::FailMatchers
+end


### PR DESCRIPTION
### Aim
Add specs for `include_all_resource_ids` matcher

#### Solution
- configure RSpec for failure matching
- refactor `include_all_resource_ids` matcher
- add specs