### PR TITLE
Add specs for include_all_resource_string_ids matcher

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,3 @@
 SimpleCov.start do
-  add_filter %r{spec/}
+  add_filter %r{/spec/dummy}
 end

--- a/lib/infinum_json_api_setup/rspec.rb
+++ b/lib/infinum_json_api_setup/rspec.rb
@@ -1,6 +1,7 @@
 require 'infinum_json_api_setup/rspec/matchers/schema_matchers'
 require 'infinum_json_api_setup/rspec/matchers/body_matchers'
 require 'infinum_json_api_setup/rspec/matchers/include_all_resource_ids'
+require 'infinum_json_api_setup/rspec/matchers/include_all_resource_string_ids'
 
 require 'infinum_json_api_setup/rspec/helpers/request_helper'
 require 'infinum_json_api_setup/rspec/helpers/response_helper'

--- a/lib/infinum_json_api_setup/rspec/matchers/body_matchers.rb
+++ b/lib/infinum_json_api_setup/rspec/matchers/body_matchers.rb
@@ -1,11 +1,3 @@
-RSpec::Matchers.define :include_all_resource_string_ids do |params|
-  match do |response|
-    body = JSON.parse(response.body)
-    resource_ids = body['data'].map { |resource| resource['id'] }
-    params.sort == resource_ids.sort
-  end
-end
-
 RSpec::Matchers.define :include_all_resource_ids_sorted do |params|
   match do |response|
     body = JSON.parse(response.body)

--- a/lib/infinum_json_api_setup/rspec/matchers/include_all_resource_ids.rb
+++ b/lib/infinum_json_api_setup/rspec/matchers/include_all_resource_ids.rb
@@ -42,8 +42,12 @@ module InfinumJsonApiSetup
           @actual_ids ||= JSON
                           .parse(response.body)
                           .fetch('data')
-                          .map { |resource| resource['id'].to_i }
+                          .map { |resource| process_id(resource['id']) }
                           .sort
+        end
+
+        def process_id(value)
+          value.to_i
         end
       end
     end

--- a/lib/infinum_json_api_setup/rspec/matchers/include_all_resource_string_ids.rb
+++ b/lib/infinum_json_api_setup/rspec/matchers/include_all_resource_string_ids.rb
@@ -1,0 +1,16 @@
+module InfinumJsonApiSetup
+  module RSpec
+    module Matchers
+      # @return [InfinumJsonApiSetup::Rspec::Matchers::IncludeAllResourceStringIds]
+      def include_all_resource_string_ids(*args)
+        IncludeAllResourceStringIds.new(*args)
+      end
+
+      class IncludeAllResourceStringIds < IncludeAllResourceIds
+        def process_id(id)
+          id
+        end
+      end
+    end
+  end
+end

--- a/spec/infinum_json_api_setup/rspec/matchers/include_all_resource_ids_spec.rb
+++ b/spec/infinum_json_api_setup/rspec/matchers/include_all_resource_ids_spec.rb
@@ -1,4 +1,6 @@
 describe InfinumJsonApiSetup::RSpec::Matchers::IncludeAllResourceIds do
+  include TestHelpers::Matchers::Response
+
   describe 'usage' do
     context "when ID's match" do
       it 'matches' do
@@ -43,13 +45,5 @@ describe InfinumJsonApiSetup::RSpec::Matchers::IncludeAllResourceIds do
         end.to fail_with('Failed to extract data from response body')
       end
     end
-  end
-
-  def response_with_ids(ids)
-    response_with_body(JSON.dump(data: ids.map { |id| { 'id' => id } }))
-  end
-
-  def response_with_body(body)
-    ActionDispatch::TestResponse.new(200, {}, body)
   end
 end

--- a/spec/infinum_json_api_setup/rspec/matchers/include_all_resource_string_ids_spec.rb
+++ b/spec/infinum_json_api_setup/rspec/matchers/include_all_resource_string_ids_spec.rb
@@ -1,0 +1,49 @@
+describe InfinumJsonApiSetup::RSpec::Matchers::IncludeAllResourceStringIds do
+  include TestHelpers::Matchers::Response
+
+  describe 'usage' do
+    context "when ID's match" do
+      it 'matches' do
+        response = response_with_ids(['1', '2'])
+
+        expect(response).to include_all_resource_string_ids(['1', '2'])
+      end
+
+      it "doesn't consider ordering" do
+        response = response_with_ids(['1', '2', '3'])
+
+        expect(response).to include_all_resource_string_ids(['3', '2', '1'])
+      end
+    end
+
+    context "when ID's don't match" do
+      it 'fails and describes failure reason' do
+        response = response_with_ids(['1', '2', '3'])
+
+        expect do
+          expect(response).to include_all_resource_string_ids(['4'])
+        end.to fail_with('Expected response ID\'s(["1", "2", "3"]) to match ["4"]')
+      end
+    end
+
+    context "when response isn't valid JSON" do
+      it 'fails and describes failure reason' do
+        response = response_with_body('')
+
+        expect do
+          expect(response).to include_all_resource_string_ids(['1'])
+        end.to fail_with('Failed to parse response body')
+      end
+    end
+
+    context "when response doesn't contain data attribute" do
+      it 'fails and describes failure reason' do
+        response = response_with_body('{}')
+
+        expect do
+          expect(response).to include_all_resource_string_ids(['1'])
+        end.to fail_with('Failed to extract data from response body')
+      end
+    end
+  end
+end

--- a/spec/support/test_helpers/matchers/response.rb
+++ b/spec/support/test_helpers/matchers/response.rb
@@ -1,0 +1,17 @@
+module TestHelpers
+  module Matchers
+    module Response
+      # @param [Array<Object>] ids
+      # @return [ActionDispatch::TestResponse]
+      def response_with_ids(ids)
+        response_with_body(JSON.dump(data: ids.map { |id| { 'id' => id } }))
+      end
+
+      # @param [String] body
+      # @return [ActionDispatch::TestResponse]
+      def response_with_body(body)
+        ActionDispatch::TestResponse.new(200, {}, body)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Aim
Add specs for `include_all_resource_string_ids` matcher

#### Solution
- generalize id processing in the `include_all_resource_ids` matcher
- subclass and override id processing in the `include_all_resource_string_ids` matcher
- add specs