### PR TITLE
Add specs for have_empty_data matcher

### DIFF
--- a/lib/infinum_json_api_setup/rspec.rb
+++ b/lib/infinum_json_api_setup/rspec.rb
@@ -1,8 +1,10 @@
 require 'infinum_json_api_setup/rspec/matchers/schema_matchers'
 require 'infinum_json_api_setup/rspec/matchers/body_matchers'
+require 'infinum_json_api_setup/rspec/matchers/match_json_data'
 require 'infinum_json_api_setup/rspec/matchers/include_all_resource_ids'
 require 'infinum_json_api_setup/rspec/matchers/include_all_resource_string_ids'
 require 'infinum_json_api_setup/rspec/matchers/include_all_resource_ids_sorted'
+require 'infinum_json_api_setup/rspec/matchers/have_empty_data'
 
 require 'infinum_json_api_setup/rspec/helpers/request_helper'
 require 'infinum_json_api_setup/rspec/helpers/response_helper'

--- a/lib/infinum_json_api_setup/rspec/matchers/body_matchers.rb
+++ b/lib/infinum_json_api_setup/rspec/matchers/body_matchers.rb
@@ -7,13 +7,6 @@ RSpec::Matchers.define :include_related_resource do |type, id|
   end
 end
 
-RSpec::Matchers.define :have_empty_data do
-  match do |response|
-    body = JSON.parse(response.body)
-    body['data'].empty?
-  end
-end
-
 RSpec::Matchers.define :have_resource_count_of do |count|
   match do |response|
     body = JSON.parse(response.body)

--- a/lib/infinum_json_api_setup/rspec/matchers/have_empty_data.rb
+++ b/lib/infinum_json_api_setup/rspec/matchers/have_empty_data.rb
@@ -1,0 +1,24 @@
+module InfinumJsonApiSetup
+  module RSpec
+    module Matchers
+      # @return [InfinumJsonApiSetup::Rspec::Matchers::HaveEmptyData]
+      def have_empty_data # rubocop:disable Naming/PredicateName
+        HaveEmptyData.new
+      end
+
+      class HaveEmptyData
+        include MatchJsonData
+
+        private
+
+        def do_matches?
+          data.empty?
+        end
+
+        def match_failure_message
+          "Expected response data(#{data}) to be empty, but isn't"
+        end
+      end
+    end
+  end
+end

--- a/lib/infinum_json_api_setup/rspec/matchers/include_all_resource_ids.rb
+++ b/lib/infinum_json_api_setup/rspec/matchers/include_all_resource_ids.rb
@@ -9,34 +9,24 @@ module InfinumJsonApiSetup
       end
 
       class IncludeAllResourceIds
+        include MatchJsonData
+
         # @param [Array<Integer>] required_ids
         def initialize(required_ids)
           @required_ids = process_required_ids(required_ids)
         end
 
-        # @param [ActionDispatch::TestResponse] response
-        # @return [Boolean]
-        def matches?(response)
-          @response = response
-
-          actual_ids == required_ids
-        rescue JSON::ParserError => _e
-          @error_message = 'Failed to parse response body'
-          false
-        rescue KeyError => _e
-          @error_message = 'Failed to extract data from response body'
-          false
-        end
-
-        # @return [String]
-        def failure_message
-          @error_message || "Expected response ID's(#{actual_ids}) to match #{required_ids}"
-        end
-
         private
 
-        attr_reader :response
+        def do_matches?
+          actual_ids == required_ids
+        end
+
         attr_reader :required_ids
+
+        def match_failure_message
+          "Expected response ID's(#{actual_ids}) to match #{required_ids}"
+        end
 
         def process_required_ids(ids)
           ids.sort
@@ -44,10 +34,7 @@ module InfinumJsonApiSetup
 
         def actual_ids
           @actual_ids ||= process_actual_ids(
-            JSON
-            .parse(response.body)
-            .fetch('data')
-            .map { |resource| process_actual_id(resource['id']) }
+            data.map { |resource| process_actual_id(resource['id']) }
           )
         end
 

--- a/lib/infinum_json_api_setup/rspec/matchers/match_json_data.rb
+++ b/lib/infinum_json_api_setup/rspec/matchers/match_json_data.rb
@@ -1,0 +1,43 @@
+module InfinumJsonApiSetup
+  module RSpec
+    module Matchers
+      module MatchJsonData
+        extend ActiveSupport::Concern
+
+        included do
+          attr_reader :response
+        end
+
+        # @param [ActionDispatch::TestResponse] response
+        # @return [Boolean]
+        def matches?(response)
+          @response = response
+          data
+
+          do_matches?
+        rescue JSON::ParserError => _e
+          @error_message = 'Failed to parse response body'
+          false
+        rescue KeyError => _e
+          @error_message = 'Failed to extract data from response body'
+          false
+        end
+
+        # @return [String]
+        def failure_message
+          @error_message || match_failure_message
+        end
+
+        private
+
+        def do_matches?; end
+
+        def match_failure_message; end
+
+        def data
+          @data ||= JSON.parse(response.body).fetch('data')
+        end
+      end
+    end
+  end
+end

--- a/spec/infinum_json_api_setup/rspec/matchers/have_empty_data_spec.rb
+++ b/spec/infinum_json_api_setup/rspec/matchers/have_empty_data_spec.rb
@@ -1,0 +1,43 @@
+describe InfinumJsonApiSetup::RSpec::Matchers::HaveEmptyData do
+  include TestHelpers::Matchers::Response
+
+  describe 'usage' do
+    context 'when data is empty' do
+      it 'matches' do
+        response = response_with_body(JSON.dump(data: {}))
+
+        expect(response).to have_empty_data
+      end
+    end
+
+    context "when data isn't empty" do
+      it 'fails and describes failure reason' do
+        response = response_with_body(JSON.dump(data: { a: 1 }))
+
+        expect do
+          expect(response).to have_empty_data
+        end.to fail_with("Expected response data({\"a\"=>1}) to be empty, but isn't")
+      end
+    end
+
+    context "when response isn't valid JSON" do
+      it 'fails and describes failure reason' do
+        response = response_with_body('')
+
+        expect do
+          expect(response).to have_empty_data
+        end.to fail_with('Failed to parse response body')
+      end
+    end
+
+    context "when response doesn't contain data attribute" do
+      it 'fails and describes failure reason' do
+        response = response_with_body('{}')
+
+        expect do
+          expect(response).to have_empty_data
+        end.to fail_with('Failed to extract data from response body')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Aim
Add specs for `have_empty_data` matcher

### Solution
- generalize and extract JSON data parsing and matching logic
- refactor include_all_resource_ids* implementations to use common JSON data parsing/matching logic
- add specs for `have_empty_data` matcher