### PR TITLE
Relax json_schemer dependency, add ostruct explicitly

### DIFF
--- a/infinum_json_api_setup.gemspec
+++ b/infinum_json_api_setup.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jsonapi-query_builder'
   s.add_dependency 'jsonapi-serializer'
   s.add_dependency 'json_schemer', '>= 0.2', '< 3'
+  s.add_dependency 'ostruct'
   s.add_dependency 'pagy', '~> 8.0'
   s.add_dependency 'rails'
   s.add_dependency 'responders'

--- a/infinum_json_api_setup.gemspec
+++ b/infinum_json_api_setup.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'jsonapi_parameters'
   s.add_dependency 'jsonapi-query_builder'
   s.add_dependency 'jsonapi-serializer'
-  s.add_dependency 'json_schemer', '~> 0.2'
+  s.add_dependency 'json_schemer', '>= 0.2', '< 3'
   s.add_dependency 'pagy', '~> 8.0'
   s.add_dependency 'rails'
   s.add_dependency 'responders'

--- a/lib/infinum_json_api_setup.rb
+++ b/lib/infinum_json_api_setup.rb
@@ -5,6 +5,7 @@ require 'json'
 require 'jsonapi_parameters'
 require 'jsonapi/serializer'
 require 'json_schemer'
+require 'ostruct'
 require 'responders'
 
 require 'pagy'

--- a/lib/infinum_json_api_setup/rspec/helpers/response_helper.rb
+++ b/lib/infinum_json_api_setup/rspec/helpers/response_helper.rb
@@ -24,7 +24,7 @@ module InfinumJsonApiSetup
           case response_type
           when :item then json_response.dig(:data, :relationships)
           when :collection then json_response[:data].pluck(:relationships)
-          else raise ArgumentError ':response_type must be one of [:item, :collection]'
+          else raise ArgumentError, ':response_type must be one of [:item, :collection]'
           end
         end
 

--- a/rails.7.1.gemfile.lock
+++ b/rails.7.1.gemfile.lock
@@ -7,6 +7,7 @@ PATH
       jsonapi-query_builder
       jsonapi-serializer
       jsonapi_parameters
+      ostruct
       pagy (~> 8.0)
       rails
       responders
@@ -174,6 +175,7 @@ GEM
     nokogiri (1.18.9-arm64-darwin)
       racc (~> 1.4)
     observer (0.1.2)
+    ostruct (0.6.3)
     overcommit (0.59.1)
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)

--- a/rails.7.1.gemfile.lock
+++ b/rails.7.1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     infinum_json_api_setup (0.0.8)
       accept_language (~> 2.0)
-      json_schemer (~> 0.2)
+      json_schemer (>= 0.2, < 3)
       jsonapi-query_builder
       jsonapi-serializer
       jsonapi_parameters
@@ -109,8 +109,6 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.0)
     drb (2.2.3)
-    ecma-re-validator (0.4.0)
-      regexp_parser (~> 2.2)
     erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.2.1)
@@ -130,11 +128,11 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.13.2)
-    json_schemer (0.2.21)
-      ecma-re-validator (~> 0.3)
+    json_schemer (2.4.0)
+      bigdecimal
       hana (~> 1.3)
       regexp_parser (~> 2.0)
-      uri_template (~> 0.7)
+      simpleidn (~> 0.2)
     jsonapi-query_builder (0.3.0)
       activerecord (>= 5)
       pagy (>= 3.5)
@@ -319,6 +317,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    simpleidn (0.2.3)
     stringio (3.1.7)
     thor (1.4.0)
     timeout (0.4.3)
@@ -327,7 +326,6 @@ GEM
     unicode-display_width (3.1.5)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri_template (0.7.0)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)

--- a/rails.8.0.gemfile.lock
+++ b/rails.8.0.gemfile.lock
@@ -7,6 +7,7 @@ PATH
       jsonapi-query_builder
       jsonapi-serializer
       jsonapi_parameters
+      ostruct
       pagy (~> 8.0)
       rails
       responders
@@ -177,6 +178,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-musl)
       racc (~> 1.4)
+    ostruct (0.6.3)
     overcommit (0.68.0)
       childprocess (>= 0.6.3, < 6)
       iniparse (~> 1.4)

--- a/rails.8.0.gemfile.lock
+++ b/rails.8.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     infinum_json_api_setup (0.0.8)
       accept_language (~> 2.0)
-      json_schemer (~> 0.2)
+      json_schemer (>= 0.2, < 3)
       jsonapi-query_builder
       jsonapi-serializer
       jsonapi_parameters
@@ -89,7 +89,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     builder (3.3.0)
     bundler-audit (0.9.2)
       bundler (>= 1.2.0, < 3)
@@ -104,8 +104,6 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
-    ecma-re-validator (0.4.0)
-      regexp_parser (~> 2.2)
     erb (5.0.2)
     erubi (1.13.1)
     factory_bot (6.5.5)
@@ -125,12 +123,11 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.13.2)
-    json_schemer (0.2.25)
-      ecma-re-validator (~> 0.3)
+    json_schemer (2.4.0)
+      bigdecimal
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       simpleidn (~> 0.2)
-      uri_template (~> 0.7)
     jsonapi-query_builder (0.3.0)
       activerecord (>= 5)
       pagy (>= 3.5)
@@ -340,7 +337,6 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     uri (1.0.3)
-    uri_template (0.7.0)
     useragent (0.16.11)
     websocket-driver (0.8.0)
       base64

--- a/spec/infinum_json_api_setup/rspec/helpers/response_helper_spec.rb
+++ b/spec/infinum_json_api_setup/rspec/helpers/response_helper_spec.rb
@@ -1,0 +1,234 @@
+describe InfinumJsonApiSetup::Rspec::Helpers::ResponseHelper do
+  include described_class
+
+  let(:response) { instance_double('Response', body: JSON.dump(payload)) } # rubocop:disable RSpec/RSpec/VerifiedDoubleReference
+
+  describe '#json_response' do
+    let(:payload) do
+      {
+        data: {
+          id: '1',
+          type: 'locations',
+          attributes: { name: 'Downtown HQ' }
+        }
+      }
+    end
+
+    it 'parses the response body with symbolized keys' do
+      expect(json_response).to eq(payload)
+    end
+  end
+
+  describe '#response_item' do
+    context 'when the response contains a single resource' do
+      let(:payload) do
+        {
+          data: {
+            id: '1',
+            type: 'locations',
+            attributes: { name: 'Downtown HQ', city: 'Zagreb' }
+          }
+        }
+      end
+
+      it 'returns an OpenStruct built from the resource attributes' do
+        expect(response_item).to have_attributes(name: 'Downtown HQ', city: 'Zagreb')
+      end
+    end
+
+    context 'when the response contains a collection' do
+      let(:payload) do
+        {
+          data: [
+            { id: '1', type: 'locations', attributes: { name: 'Downtown HQ' } }
+          ]
+        }
+      end
+
+      it 'raises an informative error' do
+        expect { response_item }.to raise_error('json response is not an item')
+      end
+    end
+  end
+
+  describe '#response_collection' do
+    context 'when the response contains a collection' do
+      let(:payload) do
+        {
+          data: [
+            { id: '1', type: 'locations', attributes: { name: 'Downtown HQ' } },
+            { id: '2', type: 'locations', attributes: { name: 'Suburb Office' } }
+          ]
+        }
+      end
+
+      it 'wraps each resource in an OpenStruct including id and type' do
+        expect(response_collection).to contain_exactly(
+          have_attributes(id: '1', type: 'locations', name: 'Downtown HQ'),
+          have_attributes(id: '2', type: 'locations', name: 'Suburb Office')
+        )
+      end
+    end
+
+    context 'when the response contains a single resource' do
+      let(:payload) do
+        {
+          data: {
+            id: '1',
+            type: 'locations',
+            attributes: { name: 'Downtown HQ' }
+          }
+        }
+      end
+
+      it 'raises an informative error' do
+        expect { response_collection }.to raise_error('json response is not a collection')
+      end
+    end
+  end
+
+  describe '#response_relationships' do
+    context 'when the response contains a single resource' do
+      let(:payload) do
+        {
+          data: {
+            relationships: {
+              label: { data: { id: '2', type: 'location_labels' } }
+            }
+          }
+        }
+      end
+
+      it 'returns the relationships hash for the primary resource' do
+        expect(response_relationships).to eq(payload[:data][:relationships])
+      end
+    end
+
+    context 'when the response contains a collection' do
+      let(:payload) do
+        {
+          data: [
+            { relationships: { label: { data: { id: '2', type: 'location_labels' } } } },
+            { relationships: { label: { data: { id: '3', type: 'location_labels' } } } }
+          ]
+        }
+      end
+
+      it 'returns the relationships for each resource' do
+        expect(response_relationships(response_type: :collection)).to eq(
+          payload[:data].pluck(:relationships)
+        )
+      end
+    end
+
+    context 'when an unsupported response type is requested' do
+      let(:payload) do
+        {
+          data: {
+            relationships: {
+              label: { data: { id: '2', type: 'location_labels' } }
+            }
+          }
+        }
+      end
+
+      it 'raises an argument error' do
+        expect { response_relationships(response_type: :unknown) }
+          .to raise_error(ArgumentError, ':response_type must be one of [:item, :collection]')
+      end
+    end
+  end
+
+  describe '#response_meta' do
+    let(:payload) do
+      {
+        data: {},
+        meta: { current_page: 2, total_pages: 5 }
+      }
+    end
+
+    it 'returns the meta section of the response' do
+      expect(response_meta).to eq(payload[:meta])
+    end
+  end
+
+  describe '#response_included' do
+    let(:payload) do
+      {
+        data: {},
+        included: [
+          {
+            id: '2',
+            type: 'location_labels',
+            attributes: { name: 'HQ Label' }
+          }
+        ]
+      }
+    end
+
+    it 'returns included resources as OpenStruct instances' do
+      expect(response_included.first).to have_attributes(id: '2', type: 'location_labels', name: 'HQ Label')
+    end
+  end
+
+  describe '#response_included_relationship' do
+    context 'when the relationship exists in the included section' do
+      let(:payload) do
+        {
+          data: {
+            relationships: {
+              label: { data: { id: '2', type: 'location_labels' } }
+            }
+          },
+          included: [
+            {
+              id: '2',
+              type: 'location_labels',
+              attributes: { name: 'HQ Label' }
+            }
+          ]
+        }
+      end
+
+      it 'returns the matching included resource' do
+        result = response_included_relationship(:label)
+
+        expect(result).to have_attributes(id: '2', type: 'location_labels', name: 'HQ Label')
+      end
+    end
+
+    context 'when the relationship data is nil' do
+      let(:payload) do
+        {
+          data: {
+            relationships: {
+              label: { data: nil }
+            }
+          },
+          included: []
+        }
+      end
+
+      it 'returns nil' do
+        expect(response_included_relationship(:label)).to be_nil
+      end
+    end
+
+    context 'when no matching included resource is present' do
+      let(:payload) do
+        {
+          data: {
+            relationships: {
+              label: { data: { id: '99', type: 'location_labels' } }
+            }
+          },
+          included: []
+        }
+      end
+
+      it 'returns nil' do
+        expect(response_included_relationship(:label)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Relax `json_schemer` version so gems (e.g. `activerecord_json_validator`) that depend on it can be updated. Needed for Rails 8 updates.

After merge and release of new version update https://github.com/infinum/rails-infinum-guess_who/pull/353 to remove the dependency on GitHub ref.

Related issue: [#1196](https://app.productive.io/1-infinum/tasks/14134282)